### PR TITLE
Fix macro expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .mypy_cachevenv
 .mypy_cache
 venv
+yapf*.py

--- a/lisby/compiler/compiler.py
+++ b/lisby/compiler/compiler.py
@@ -18,8 +18,12 @@ def nodes_to_str(expr) -> str:
 
 
 class Macro:
-    def __init__(self, c: "Compiler", p: Program, name: str,
-                 params: List[str], body: List[Node],
+    def __init__(self,
+                 c: "Compiler",
+                 p: Program,
+                 name: str,
+                 params: List[str],
+                 body: List[Node],
                  debug: bool = False) -> None:
         self.name = name
         self.params = params
@@ -67,7 +71,7 @@ class Macro:
 
 
 class Compiler:
-    def __init__(self, debug: bool=False) -> None:
+    def __init__(self, debug: bool = False) -> None:
         self.debug = debug
         self.macros: Dict[str, Macro] = {}
         self.forms: Dict[str, Callable[[Program, Application], None]] = {
@@ -106,8 +110,8 @@ class Compiler:
 
     def _symbol_apply(self, p: Program, app: Application) -> None:
         sym, args = app.applier(), app.args()
-        self._debug("symbol apply: %s with args %s " % (
-            sym, nodes_to_str(args)))
+        self._debug("symbol apply: %s with args %s " %
+                    (sym, nodes_to_str(args)))
         symindex = p.symbol_find(sym.value)
         self._compile_list(p, args)
         self._push_symbol(p, sym)
@@ -143,18 +147,15 @@ class Compiler:
             p.emit(Op.Type.PUSHUNIT)
         else:
             raise LisbySyntaxError(
-                atom,
-                "Atom expected, got %s (%s)" % (
-                    nodes_to_str(atom), type(atom).__name__))
+                atom, "Atom expected, got %s (%s)" %
+                (nodes_to_str(atom), type(atom).__name__))
 
     def _or(self, p: Program, node: Application) -> None:
         """_or generates the short-circuiting boolean OR"""
         self._debug("or")
         orr = node.args()
         if len(orr) != 2:
-            raise LisbySyntaxError(
-                node,
-                "or expects two arguments")
+            raise LisbySyntaxError(node, "or expects two arguments")
         first, second = orr
         self._compile(p, first)
         p.emit(Op.Type.JT)
@@ -178,9 +179,7 @@ class Compiler:
         self._debug("and")
         orr = node.args()
         if len(orr) != 2:
-            raise LisbySyntaxError(
-                node,
-                "and expects two arguments")
+            raise LisbySyntaxError(node, "and expects two arguments")
         # Our goal is to compile the following:
         # - evaluate first condition
         # - it it failed, jump to a PUSHFALSE
@@ -210,8 +209,7 @@ class Compiler:
         args = node.args()
         if len(args) < 2:
             raise LisbySyntaxError(
-                node,
-                "List concatenation needs at least two parameters")
+                node, "List concatenation needs at least two parameters")
         for arg in args:
             self._compile(p, arg)
         for n in range(len(args) - 1):
@@ -222,14 +220,12 @@ class Compiler:
         self._debug("defmacro")
         args = node.args()
         if len(args) < 2:
-            raise LisbySyntaxError(
-                node,
-                "defmacro needs at least two parameters")
+            raise LisbySyntaxError(node,
+                                   "defmacro needs at least two parameters")
         if not isinstance(args[0], Application):
             raise LisbySyntaxError(
                 args[0],
-                "No macro parameters given, got %s" % (
-                    type(args[0]).__name__))
+                "No macro parameters given, got %s" % (type(args[0]).__name__))
         rawparams = args[0].tolist()
         if len(rawparams) == 0:
             raise LisbySyntaxError(rawparams, "Need at least macro name")
@@ -237,9 +233,8 @@ class Compiler:
         for param in rawparams:
             if not isinstance(param, Symbol):
                 raise LisbySyntaxError(
-                    param,
-                    "Macro parameter not a symbol, got %s" % (
-                        type(param).__name__))
+                    param, "Macro parameter not a symbol, got %s" %
+                    (type(param).__name__))
             params.append(param.value)
         name = params[0]
         params = params[1:]
@@ -248,8 +243,7 @@ class Compiler:
             raise LisbySyntaxError(node, "Macro %s already defined" % name)
         if name in self.forms:
             raise LisbySyntaxError(
-                node,
-                "Macro name %s collides with a special form" % name)
+                node, "Macro name %s collides with a special form" % name)
         self.macros[name] = Macro(self, p, name, params, args[1:], self.debug)
 
     ccerr = ("call/cc parameter has to be a lambda expression " +
@@ -260,29 +254,27 @@ class Compiler:
         self._debug("call/cc")
         args = node.args()
         if len(args) != 1:
-            raise LisbySyntaxError(
-                node,
-                "call/cc accepts only one paramter")
+            raise LisbySyntaxError(node, "call/cc accepts only one paramter")
         param = args[0]
         if not isinstance(param, Application):
-            raise LisbySyntaxError(
-                node, Compiler.ccerr % (type(param).__name__, 1))
+            raise LisbySyntaxError(node,
+                                   Compiler.ccerr % (type(param).__name__, 1))
         parargs = param.tolist()
         if len(parargs) < 2:
-            raise LisbySyntaxError(
-                node, Compiler.ccerr % (type(param).__name__, 2))
+            raise LisbySyntaxError(node,
+                                   Compiler.ccerr % (type(param).__name__, 2))
         if not isinstance(parargs[0], Symbol) or parargs[0].value != "lambda":
-            raise LisbySyntaxError(
-                node, Compiler.ccerr % (type(param).__name__, 3))
+            raise LisbySyntaxError(node,
+                                   Compiler.ccerr % (type(param).__name__, 3))
         binds = parargs[1]
         self._debug(binds)
         if not isinstance(binds, Application) or len(binds.tolist()) != 1:
-            raise LisbySyntaxError(
-                node, Compiler.ccerr % (type(param).__name__, 4))
+            raise LisbySyntaxError(node,
+                                   Compiler.ccerr % (type(param).__name__, 4))
         exprs = parargs[2:]
         if not isinstance(binds, Application):
-            raise LisbySyntaxError(
-                node, Compiler.ccerr % (type(param).__name__, 5))
+            raise LisbySyntaxError(node,
+                                   Compiler.ccerr % (type(param).__name__, 5))
         params = binds.tolist()
         p.emit(Op.Type.PUSHCONT)
         patch_cont_end = p.emitpholder()
@@ -312,9 +304,8 @@ class Compiler:
         self._debug("begin")
         args = node.args()
         if len(args) == 0:
-            raise LisbySyntaxError(
-                node,
-                "begin form needs at least one expression")
+            raise LisbySyntaxError(node,
+                                   "begin form needs at least one expression")
         self._compile_exprs(p, args)
 
     def _set(self, p: Program, node: Application) -> None:
@@ -326,9 +317,7 @@ class Compiler:
                 "set! form expects two arguments, binding and expression")
         target, val = args
         if not isinstance(target, Symbol):
-            raise LisbySyntaxError(
-                target,
-                "set! target should be a symbol")
+            raise LisbySyntaxError(target, "set! target should be a symbol")
         self._compile(p, val)
         self._store(p, target.value)
         p.emit(Op.Type.PUSHUNIT)
@@ -384,8 +373,8 @@ class Compiler:
             self._application(p, app)
             p.emit(Op.Type.CALL)
         else:
-            raise LisbySyntaxError(node, "Cannot apply with %s" % type(
-                node).__name__)
+            raise LisbySyntaxError(
+                node, "Cannot apply with %s" % type(node).__name__)
 
     def _lambda(self, p: Program, node: Application) -> None:
         # Our lambda form is straight from Scheme:
@@ -394,9 +383,8 @@ class Compiler:
         self._debug("lambda: %s" % nodes_to_str(node.tolist()))
         if len(args) < 2:
             raise LisbySyntaxError(
-                node,
-                "lambda form needs at least two parameters, got %d" % len(
-                    args))
+                node, "lambda form needs at least two parameters, got %d" %
+                len(args))
         params: List[Node] = None
         if isinstance(args[0], Application):
             params = args[0].tolist()

--- a/lisby/compiler/compiler.py
+++ b/lisby/compiler/compiler.py
@@ -1,4 +1,5 @@
 from typing import List, Callable, Dict
+from copy import deepcopy
 from struct import pack
 
 from lisby.shared import LisbySyntaxError
@@ -51,16 +52,17 @@ class Macro:
         return n
 
     def expand(self, n: Application) -> None:
-        self._debug("`%s' of node %s" % (self.name, n))
         args = n.args()
+        self._debug("`%s' of node %s" % (self.name, n))
         if len(args) != len(self.params):
             raise LisbySyntaxError(
-                n,
-                "Macro %s expects %d arguments, got %d" % (
-                    self.name, len(self.params), len(args)))
+                n, "Macro %s expects %d arguments, got %d" %
+                (self.name, len(self.params), len(args)))
+        body_orig = deepcopy(self.body)
         for node in self.body:
             node = self._expand(args, node)
             self.compiler._compile(self.program, node)
+        self.body = body_orig
         self._debug("finished expansion")
 
 

--- a/lisby/parser/node.py
+++ b/lisby/parser/node.py
@@ -9,7 +9,10 @@ class NodeError(Exception):
 
 
 class Node:
-    def __init__(self, token: plex.LexToken, arity: int, left=None,
+    def __init__(self,
+                 token: plex.LexToken,
+                 arity: int,
+                 left=None,
                  right=None) -> None:
         if arity == 1:
             if left is None:

--- a/lisby/tests/test_system.py
+++ b/lisby/tests/test_system.py
@@ -392,10 +392,16 @@ class TestSystem(unittest.TestCase):
         vm = self.invoke("""
 (defmacro (multiplier a b) (* a b))
 (multiplier 5 6)
-        """, debug=True)
-        res = vm.stack[-1]
-        self.assertTrue(isinstance(res, Int), res)
-        self.assertEqual(res.value, 30)
+(+ (multiplier 10 7) 5)
+        """,
+                         debug=True)
+        second = vm.stack[-1]
+        vm.stack.pop()
+        first = vm.stack[-1]
+        for v in ((first, 30), (second, 75)):
+            print(v)
+            self.assertTrue(isinstance(v[0], Int), v)
+            self.assertEqual(v[0].value, v[1], f"got {v[0]}, want {v[1]}")
 
     def test_defmacro_looper(self):
         vm = self.invoke("""

--- a/lisby/tests/test_system.py
+++ b/lisby/tests/test_system.py
@@ -17,9 +17,8 @@ class TestSystem(unittest.TestCase):
         parser = Parser(debug=False)
         compiler = Compiler(debug=debug)
         vm = VM()
-        vm.run(compiler.compile(
-            Program(),
-            parser.parse(lexer.lex(code))), trace=debug)
+        vm.run(compiler.compile(Program(), parser.parse(lexer.lex(code))),
+               trace=debug)
         return vm
 
     def test_arith(self):
@@ -27,9 +26,7 @@ class TestSystem(unittest.TestCase):
         self.assertEqual(vm.stack[-1].value, 16)
 
     def test_mod(self):
-        tests = (
-            ("(% 20 5)", 0),
-            ("(% -5 10)", 5))
+        tests = (("(% 20 5)", 0), ("(% -5 10)", 5))
         for test in tests:
             vm = self.invoke(test[0])
             val = vm.stack[-1]
@@ -37,11 +34,9 @@ class TestSystem(unittest.TestCase):
             self.assertEqual(val.value, test[1])
 
     def test_bits(self):
-        tests = (
-            ("(| 170 85)", 170 | 85),
-            ("(^ 255 128)", 255 ^ 128),
-            ("(& 255 7)", 255 & 7),
-            ("(~ 170)", ~170 & 0xFFFFFFFFFFFFFFFF))
+        tests = (("(| 170 85)", 170 | 85), ("(^ 255 128)", 255 ^ 128),
+                 ("(& 255 7)", 255 & 7), ("(~ 170)",
+                                          ~170 & 0xFFFFFFFFFFFFFFFF))
         for test in tests:
             print("bit test: %s " % test[0])
             vm = self.invoke(test[0])
@@ -62,8 +57,8 @@ class TestSystem(unittest.TestCase):
             print("cond test: %s" % test[0])
             vm = self.invoke(test[0])
             self.assertTrue(
-                isinstance(vm.stack[-1], VTrue) or
-                isinstance(vm.stack[-1], VFalse))
+                isinstance(vm.stack[-1], VTrue)
+                or isinstance(vm.stack[-1], VFalse))
             self.assertEqual(vm.stack[-1].value, test[1])
 
     def test_let(self):
@@ -139,11 +134,8 @@ class TestSystem(unittest.TestCase):
         self.assertEqual(vm.stack[-1].value, 30)
 
     def test_or(self):
-        tests = (
-            ("(or #f #f)", False),
-            ("(or #t #f)", True),
-            ("(or #t #t)", True),
-            ("(or #f #t)", True))
+        tests = (("(or #f #f)", False), ("(or #t #f)", True),
+                 ("(or #t #t)", True), ("(or #f #t)", True))
         for test in tests:
             print("or: %s" % test[0])
             vm = self.invoke(test[0])
@@ -156,11 +148,8 @@ class TestSystem(unittest.TestCase):
             self.assertEqual(val.value, test[1])
 
     def test_and(self):
-        tests = (
-            ("(and #f #f)", False),
-            ("(and #t #f)", False),
-            ("(and #t #t)", True),
-            ("(and #f #t)", False))
+        tests = (("(and #f #f)", False), ("(and #t #f)", False),
+                 ("(and #t #t)", True), ("(and #f #t)", False))
         for test in tests:
             print("and: %s" % test[0])
             vm = self.invoke(test[0])
@@ -214,9 +203,7 @@ class TestSystem(unittest.TestCase):
         p = vm.program
         env = vm.topenv
         for var in (("eka", 11), ("toka", 21), ("kolmas", 12), ("neljas", 22)):
-            self.assertEqual(
-                env.values[p.symbol_find(var[0])].value,
-                var[1])
+            self.assertEqual(env.values[p.symbol_find(var[0])].value, var[1])
         self.assertEqual(env.values[p.symbol_find("counter")].value, 4)
 
     def test_recursion(self):
@@ -230,9 +217,8 @@ class TestSystem(unittest.TestCase):
         """ % n)
         p = vm.program
         env = vm.topenv
-        self.assertEqual(
-            env.values[p.symbol_find("result")].value,
-            factorial(n))
+        self.assertEqual(env.values[p.symbol_find("result")].value,
+                         factorial(n))
 
     def test_naive_fibonacci(self):
         n = 10
@@ -250,9 +236,7 @@ class TestSystem(unittest.TestCase):
         """ % n)
         p = vm.program
         env = vm.topenv
-        self.assertEqual(
-            env.values[p.symbol_find("result")].value,
-            55)
+        self.assertEqual(env.values[p.symbol_find("result")].value, 55)
 
     def test_list(self):
         vm = self.invoke("""


### PR DESCRIPTION
Our macro-expansion logic was accidentally storing too much state.
There may be a neater fix hidden somewhere under the expansion logic,
however this probably does the trick.